### PR TITLE
catch reader errors in RequestFilter

### DIFF
--- a/src/main/java/net/netzgut/integral/internal/resteasy/ResteasyRequestFilter.java
+++ b/src/main/java/net/netzgut/integral/internal/resteasy/ResteasyRequestFilter.java
@@ -53,6 +53,7 @@ import org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher;
 import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ReaderException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.ResteasyUriInfo;
 import org.jboss.resteasy.util.GetRestful;
@@ -120,8 +121,15 @@ public class ResteasyRequestFilter implements HttpServletRequestFilter, HttpRequ
             this.checkForUpdatesFilter.service(null, null, this.dummyHandler);
         }
 
-        this.servletContainerDispatcher.service(request.getMethod(), request, response, true);
-        this.headerProviderManager.provide(request, response);
+        try {
+            this.servletContainerDispatcher.service(request.getMethod(), request, response, true);
+            this.headerProviderManager.provide(request, response);
+        }
+        // this exception is thrown when request contains illegal characters
+        catch (ReaderException ex) {
+            log.warn("Problem occured reading REST request: " + ex.getMessage(), ex);
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
this PR contains a try/catch clause to get hold of errors when resteasy / jackson is trying to decode requests which contains control-characters and cannot be decoded.

When the exception is not caught tapestry will report an error which should in my opinion be a warning instead.